### PR TITLE
make automatic preprocessing optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 Lexical analyzer library for C programming language in NodeJS
 
 ### Usage
-There are two units in the library - preprocessing unit and lexical analyzing 
-unit. These two units can be used independently. Purpose of including 
-preprocessing unit within the library is so that user can remove the 
+There are two units in the library - preprocessing unit and lexical analyzing
+unit. These two units can be used independently. Purpose of including
+preprocessing unit within the library is so that user can remove the
 preprocessor with it and then feed it to scanning unit to get token stream.
 
 ##### Preprocessing Unit
@@ -19,6 +19,25 @@ lexer.cppUnit.clearPreprocessors("./a.c", function(err, codeText){
         /* Do what you want to do with preprocessor free code text */
     }
 });
+```
+The clearPreprocessors method by default invokes `cpp` on the first arguement,
+producing an intermediate preprocessed file. It then finalizes the output by stripping
+the output of the preprocessor from the intermediate file and passing it to your callback
+as codeText.
+
+If you already have preprocessed files (.ii) at hand, you can skip the preprocessing step
+by passing the path to your preprocessed file as your last arguement.
+
+```js
+var lexer = require("node-c-lexer");
+lexer.cppUnit.clearPreprocessors("./a.c", function(err, codeText){
+    if(err){
+        /* Some error occured */
+    }
+    else{
+        /* Do what you want to do with preprocessor free code text */
+    }
+}, "./a.ii");
 ```
 
 ##### Scanning Unit
@@ -40,5 +59,5 @@ object. Format of a single token is following
     "child": null
 }
 ```
-```parent``` and ```child``` 
+```parent``` and ```child```
 these two are kept so that parse tree can be built using the tokens as nodes.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ as codeText.
 If you already have preprocessed files (.ii) at hand, you can skip the preprocessing step
 by passing the path to your preprocessed file as your last arguement.
 
+A reason why would want to do something like this is if you, for instance, have a
+separate environment on which your .ii(s) are generated(e.g preprocessed files are produced
+within your windows bash environment). Or if your preprocessing pass diverges from
+the execution of a simple 'cpp' command in general.
 ```js
 var lexer = require("node-c-lexer");
 lexer.cppUnit.clearPreprocessors("./a.c", function(err, codeText){

--- a/lib/cpp-unit.js
+++ b/lib/cpp-unit.js
@@ -2,63 +2,94 @@ var exec = require("child_process").exec;
 var uuid = require("uuid");
 var fs = require("fs");
 
-var clearPreprocessors = function(fileName, cb){
+/**
+ * Extracts preprocessor directives from a file
+ * with the 'cpp' command that's in your PATH.
+ * @param {string} fileName - Absolute path to the input file.
+ * @param {outputCallback} cb - function called with the output (codeText)
+ * @param {string} outFile - An optional paramater that is assummed
+ *  To be the corresponding preprocessed file, when provided
+ *  Automatic preprocessing with 'cpp' is omitted.
+ */
+var clearPreprocessors = function(fileName, cb, outFile){
     var cppFileName = uuid.v1();
     var commandToExecute = "cpp" + " " + fileName + " " + cppFileName;
-    exec(commandToExecute, function(err, stdout, stderr){
-        if(!err){
-            var lineReader = require('readline').createInterface({
-                input: require('fs').createReadStream(cppFileName)
-            });
-            
-            var onOffFlag = false;
-            var listOfLines = [];
-            var codeText = "";
-            var prevLine = "";
-            var currentMainFileLine = 0;
-            var currentlyReadLine = 0;
-            var currentlyWrittenLine = 0;
+    if (outFile != null){
+        clearPPportion(fileName, outFile, cb, false);
+    }
+    else{
+        exec(commandToExecute, function(err, stdout, stderr){
+            if(!err){
+                clearPPportion(fileName, cppFileName, cb, true);
+            }
+            else{
+                cb(err);
+            }
+        });
+    }
 
-            lineReader.on('line', function (line) {
-                currentlyReadLine += 1;
-                var tokens = line.split(" ");
-                if(tokens[0] == "#"){
-                    var fileNameToMatch = '"' + fileName + '"';
-                    if((tokens[2] == fileNameToMatch)){
-                        onOffFlag = true;
-                        currentMainFileLine = parseInt(tokens[1]);
-                        if((currentMainFileLine - currentlyWrittenLine) >= 2){
-                            listOfLines.push("");
-                            currentlyWrittenLine += 1;
-                        }
-                        else if(currentMainFileLine <= currentlyWrittenLine){
-                            listOfLines.pop();
-                            currentlyWrittenLine -= 1;
-                        }
+    /**
+     * Extracts preprocessor directives from an already
+     * preprocessed file
+     * @param {string} original - Absolute path to the unpreprocessed file.
+     * @param {string} preprocessed - Absolute path the the coresseponding preprocessed file.
+     * @param {outputCallback} cb - function called with the output (codeText)
+     * @param {bool} delPreprocessed - delete (preprocessed) if true
+     */
+    function clearPPportion(original, preprocessed, cb, delPreprocessed){
+        var cppFileName = preprocessed;
+        var fileName = original;
+        var lineReader = require('readline').createInterface({
+            input: require('fs').createReadStream(cppFileName)
+        });
+
+        var onOffFlag = false;
+        var listOfLines = [];
+        var codeText = "";
+        var prevLine = "";
+        var currentMainFileLine = 0;
+        var currentlyReadLine = 0;
+        var currentlyWrittenLine = 0;
+
+        lineReader.on('line', function (line) {
+            currentlyReadLine += 1;
+            var tokens = line.split(" ");
+            if(tokens[0] == "#"){
+                var fileNameToMatch = '"' + fileName + '"';
+                if((tokens[2] == fileNameToMatch)){
+                    onOffFlag = true;
+                    currentMainFileLine = parseInt(tokens[1]);
+                    if((currentMainFileLine - currentlyWrittenLine) >= 2){
+                        listOfLines.push("");
+                        currentlyWrittenLine += 1;
                     }
-                    else{
-                        onOffFlag = false;
+                    else if(currentMainFileLine <= currentlyWrittenLine){
+                        listOfLines.pop();
+                        currentlyWrittenLine -= 1;
                     }
                 }
-                else if(onOffFlag){
-                    listOfLines.push(line);
-                    currentlyWrittenLine += 1;
+                else{
+                    onOffFlag = false;
                 }
-                prevLine = line;
-            });
+            }
+            else if(onOffFlag){
+                listOfLines.push(line);
+                currentlyWrittenLine += 1;
+            }
+            prevLine = line;
+        });
 
-            lineReader.on('close', function() {
-                //fs.writeFile("z", codeText, function(err) {
-				//});
+        lineReader.on('close', function() {
+            if (delPreprocessed){
                 commandToExecute = "rm " + cppFileName;
                 exec(commandToExecute, function(err, stdout, stderr){
                     cb(null, listOfLines.join("\n"));
                 });
-            });
-        }
-        else{
-            cb(err);
-        }
-    });
+            }
+            else{
+                cb(null, listOfLines.join("\n"));
+            }
+        });
+    }
 }
 module.exports.clearPreprocessors = clearPreprocessors;


### PR DESCRIPTION
With this PR callers can chose to opt out of the module's automatic preprocessing by passing the default exported function an optional path to the already preprocessed output.

The API could use a rework, for example allowing the default exported function to take in 2 callbacks instead of 1, for either failure or success. 